### PR TITLE
Set random seed for opencv

### DIFF
--- a/dsacstar/dsacstar.cpp
+++ b/dsacstar/dsacstar.cpp
@@ -73,7 +73,9 @@ int dsacstar_rgb_forward(
 	float maxReproj,
 	int subSampling)
 {
-	ThreadRand::init();
+	// Set random seeds.
+    ThreadRand::init(42);
+    cv::setRNGSeed(42);
 
 	// access to tensor objects
 	dsacstar::coord_t sceneCoordinates = 


### PR DESCRIPTION
You are using RANSAC based P3P for camera pose estimation. If you dont set random seed for opecv, the results are not reproducible, every time you run testing you get new results. With this small fix, your the testing is more stable.  